### PR TITLE
fixed idrislang.sty comment for wrong macro name

### DIFF
--- a/idrislang.sty
+++ b/idrislang.sty
@@ -14,7 +14,7 @@
 %%   + Defines a `code' environment for typesetting idris.
 %%      + \begin{code}[...] ... \end{code}
 %%   + Defines an input command for externally defined idris files.
-%%      + \inputIdrisListing[...]{file.idr}
+%%      + \\idrisinput[...]{file.idr}
 %%   + Provides definitions (from Idris Compiler) for pretty-printing Idris
 %%     code using Fancy Verbatim and colour commands.
 %%      + Sets commandchars for latex commands.


### PR DESCRIPTION
renamed \inputIdrisListing to \idrisinput in the describing comment of the file